### PR TITLE
bug fix which caused testing to fail on newer versions of bash

### DIFF
--- a/executor.py
+++ b/executor.py
@@ -292,6 +292,7 @@ class Executor:
         """
         if self.shell == None:
             child = pexpect.spawnu('/bin/bash', echo=False, timeout=None)
+            child.sendline("bind 'set enable-bracketed-paste off'")
             ps1 = PEXPECT_PROMPT[:5] + u'\[\]' + PEXPECT_PROMPT[5:]
             ps2 = PEXPECT_CONTINUATION_PROMPT[:5] + u'\[\]' + PEXPECT_CONTINUATION_PROMPT[5:]
             prompt_change = u"PS1='{0}' PS2='{1}' PROMPT_COMMAND=''".format(ps1, ps2)


### PR DESCRIPTION
Bash versions 5.1 and above were encoding the commands sent from Innovation Engine with notation saying they were being pasted. This resulted in the output of things like `echo hello world` turning into '\x1b[?2004l\r\x1b[?2004h\x1b[?2004l\rHello world\r\n\x1b[?2004h''

The fix was to add a line into the repl which specifies to ignore the pasted encoding.