### PR TITLE
Alterntives to envsubst

### DIFF
--- a/scenarios/ocd/CreateAKSDeployment/README.md
+++ b/scenarios/ocd/CreateAKSDeployment/README.md
@@ -305,9 +305,8 @@ Cert-manager provides Helm charts as a first-class method of installation on Kub
     The issuer we are using can be found in the `cluster-issuer-prod.yml file`
 
     ```bash
-    export PATH=$PATH:$(go env GOPATH)/bin
-    go install github.com/a8m/envsubst/cmd/envsubst@v1.4.2
-    envsubst < cluster-issuer-prod.yml | kubectl apply -f -
+    cluster_issuer_variables=$(<cluster-issuer-prod.yml)
+    echo "${cluster_issuer_variables//\$SSL_EMAIL_ADDRESS/$SSL_EMAIL_ADDRESS}" | kubectl apply -f -
     ```
 
 5. Upate Voting App Application to use Cert-Manager to obtain an SSL Certificate.
@@ -315,7 +314,8 @@ Cert-manager provides Helm charts as a first-class method of installation on Kub
     The full YAML file can be found in `azure-vote-nginx-ssl.yml`
 
     ```bash
-    envsubst < azure-vote-nginx-ssl.yml | kubectl apply -f -
+    azure_vote_nginx_ssl_variables=$(<azure-vote-nginx-ssl.yml)
+    echo "${azure_vote_nginx_ssl_variables//\$FQDN/$FQDN}" | kubectl apply -f -
     ```
 
 ## Validate application is working


### PR DESCRIPTION
Since not all customers have go installed an alternative to envsubst binary shipped in Ubuntu distros by the package [getext-base](https://packages.ubuntu.com/jammy/amd64/gettext-base/filelist) is to use bash parameter substitution.

We can also simply pass the variables directly to the kubectl command using --env and reworking a bit the deployment files.