### PR TITLE
Fix lamp scenario

### DIFF
--- a/internal/az/group.go
+++ b/internal/az/group.go
@@ -32,7 +32,7 @@ func FindAllDeployedResourceURIs(resourceGroup string) []string {
 
 // Find the resource group name from the output of an az command.
 func FindResourceGroupName(commandOutput string) string {
-	matches := patterns.AzCommand.FindStringSubmatch(commandOutput)
+	matches := patterns.AzResourceURI.FindStringSubmatch(commandOutput)
 	if len(matches) > 1 {
 		return matches[1]
 	}

--- a/internal/engine/execution.go
+++ b/internal/engine/execution.go
@@ -83,6 +83,8 @@ func (e *Engine) ExecuteAndRenderSteps(steps []Step, env map[string]string) erro
 			)
 			if err != nil {
 				logging.GlobalLogger.Errorf("Failed to render command: %s", err.Error())
+				azureStatus.SetError(err)
+				environments.ReportAzureStatus(azureStatus, e.Configuration.Environment)
 				return err
 			}
 			finalCommandOutput := indentMultiLineCommand(renderedCommand.StdOut, 4)

--- a/internal/engine/execution.go
+++ b/internal/engine/execution.go
@@ -53,7 +53,7 @@ func filterDeletionCommands(steps []Step, preserveResources bool) []Step {
 // Executes the steps from a scenario and renders the output to the terminal.
 func (e *Engine) ExecuteAndRenderSteps(steps []Step, env map[string]string) error {
 
-	var resourceGroupName string
+	var resourceGroupName string = ""
 	var azureStatus = environments.NewAzureDeploymentStatus()
 
 	stepsToExecute := filterDeletionCommands(steps, e.Configuration.DoNotDelete)
@@ -175,6 +175,7 @@ func (e *Engine) ExecuteAndRenderSteps(steps []Step, env map[string]string) erro
 							// Extract the resource group name from the command output if
 							// it's not already set.
 							if resourceGroupName == "" && patterns.AzCommand.MatchString(block.Content) {
+                logging.GlobalLogger.Info("Attempting to extract resource group name from command output")
 								tmpResourceGroup := az.FindResourceGroupName(commandOutput.StdOut)
 								if tmpResourceGroup != "" {
 									logging.GlobalLogger.WithField("resourceGroup", tmpResourceGroup).Info("Found resource group")

--- a/scenarios/ocd/CreateLinuxVMLAMP/README.md
+++ b/scenarios/ocd/CreateLinuxVMLAMP/README.md
@@ -447,7 +447,7 @@ write_files:
         }
 
 runcmd:
-  - sed -i "s/;cgi.fix_pathinfo.*/cgi.fix_pathinfo = 1/" /etc/php/8.1/fpm/php.ini
+  - sed -i 's/;cgi.fix_pathinfo.*/cgi.fix_pathinfo = 1/' /etc/php/8.1/fpm/php.ini
   - sed -i 's/^max_execution_time \= .*/max_execution_time \= 300/g' /etc/php/8.1/fpm/php.ini
   - sed -i 's/^upload_max_filesize \= .*/upload_max_filesize \= 64M/g' /etc/php/8.1/fpm/php.ini
   - sed -i 's/^post_max_size \= .*/post_max_size \= 64M/g' /etc/php/8.1/fpm/php.ini


### PR DESCRIPTION
One of the sed expressions in the cloud-init config creation was using double quotations around wildcard statements which caused bash to attempt a variable expansion within that statement. The sed expression has been udpated to use single quotes and the document has been reformatted by markdownlint.