### PR TITLE
Clean up the environment variable state file while running in cloud shell

### DIFF
--- a/internal/engine/execution.go
+++ b/internal/engine/execution.go
@@ -266,8 +266,15 @@ func (e *Engine) ExecuteAndRenderSteps(steps []Step, env map[string]string) erro
 	switch e.Configuration.Environment {
 	case environments.EnvironmentsAzure, environments.EnvironmentsOCD:
 		logging.GlobalLogger.Info(
-			"Not resetting environment variable state to retain for cloudshell.",
+			"Cleaning environment variable file located at /tmp/env-vars",
 		)
+		err := shells.CleanEnvironmentStateFile()
+
+		if err != nil {
+			logging.GlobalLogger.Errorf("Error cleaning environment variables: %s", err.Error())
+			return err
+		}
+
 	default:
 		shells.ResetStoredEnvironmentVariables()
 	}

--- a/internal/shells/bash.go
+++ b/internal/shells/bash.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"golang.org/x/sys/unix"
@@ -70,6 +71,42 @@ func appendToBashHistory(command string, filePath string) error {
 // Resets the stored environment variables file.
 func ResetStoredEnvironmentVariables() error {
 	return os.Remove(environmentStateFile)
+}
+
+var environmentVariableName = regexp.MustCompile("^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+func filterInvalidKeys(envMap map[string]string) map[string]string {
+	validEnvMap := make(map[string]string)
+	for key, value := range envMap {
+		if environmentVariableName.MatchString(key) {
+			validEnvMap[key] = value
+		}
+	}
+	return validEnvMap
+}
+
+func CleanEnvironmentStateFile() error {
+	env, err := loadEnvFile(environmentStateFile)
+
+	if err != nil {
+		return err
+	}
+
+	env = filterInvalidKeys(env)
+
+	file, err := os.Create(environmentStateFile)
+	if err != nil {
+		return err
+	}
+
+	writer := bufio.NewWriter(file)
+	for k, v := range env {
+		_, err := fmt.Fprintf(writer, "%s=%s\n", k, v)
+		if err != nil {
+			return err
+		}
+	}
+	return writer.Flush()
 }
 
 type CommandOutput struct {

--- a/internal/shells/bash_test.go
+++ b/internal/shells/bash_test.go
@@ -1,0 +1,66 @@
+package shells
+
+import (
+	"testing"
+)
+
+func TestEnvironmentVariableValidationAndFiltering(t *testing.T) {
+	// Test key validation
+	t.Run("Key Validation", func(t *testing.T) {
+		validCases := []struct {
+			key      string
+			expected bool
+		}{
+			{"ValidKey", true},
+			{"VALID_VARIABLE", true},
+			{"_AnotherValidKey", true},
+			{"123Key", false},                   // Starts with a digit
+			{"key-with-hyphen", false},          // Contains a hyphen
+			{"key.with.dot", false},             // Contains a period
+			{"Fabric_NET-0-[Delegated]", false}, // From cloud shell environment.
+		}
+
+		for _, tc := range validCases {
+			t.Run(tc.key, func(t *testing.T) {
+				result := environmentVariableName.MatchString(tc.key)
+				if result != tc.expected {
+					t.Errorf(
+						"Expected isValidKey(%s) to be %v, got %v",
+						tc.key,
+						tc.expected,
+						result,
+					)
+				}
+			})
+		}
+	})
+
+	// Test key filtering
+	t.Run("Key Filtering", func(t *testing.T) {
+		envMap := map[string]string{
+			"ValidKey":                 "value1",
+			"_AnotherValidKey":         "value2",
+			"123Key":                   "value3",
+			"key-with-hyphen":          "value4",
+			"key.with.dot":             "value5",
+			"Fabric_NET-0-[Delegated]": "false", // From cloud shell environment.
+		}
+
+		validEnvMap := filterInvalidKeys(envMap)
+
+		expectedValidEnvMap := map[string]string{
+			"ValidKey":         "value1",
+			"_AnotherValidKey": "value2",
+		}
+
+    if len(validEnvMap) != len(expectedValidEnvMap) {
+      t.Errorf("Expected validEnvMap to have %d keys, got %d", len(expectedValidEnvMap), len(validEnvMap))
+    }
+
+		for key, value := range validEnvMap {
+			if expectedValue, ok := expectedValidEnvMap[key]; !ok || value != expectedValue {
+				t.Errorf("Expected validEnvMap[%s] to be %s, got %s", key, expectedValue, value)
+			}
+		}
+	})
+}


### PR DESCRIPTION
In order to save the state of variables exported in a scenario execution, we capture and save the environment variables into a file after each command gets executed. This allows the portal to source the environment variables from that file after the innovation engine exits so that the user has access to the environment variables exported during a scenario run. However, Cloud Shell exports the variable `Fabric_NET-0-[Delegated]` into the users environment which contains illegal characters for a bash variable name. This PR cleans up the environment variables file when running in Cloud Shell so that there are no errors when sourcing the environment variable file after ie finishes executing.