### PR TITLE
Fix subscription setting errors to be reported in the portal.

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -6,7 +6,6 @@ import (
 	"github.com/Azure/InnovationEngine/internal/az"
 	"github.com/Azure/InnovationEngine/internal/lib"
 	"github.com/Azure/InnovationEngine/internal/lib/fs"
-	"github.com/Azure/InnovationEngine/internal/logging"
 	"github.com/Azure/InnovationEngine/internal/ui"
 )
 
@@ -26,12 +25,6 @@ type Engine struct {
 
 // / Create a new engine instance.
 func NewEngine(configuration EngineConfiguration) (*Engine, error) {
-	err := az.SetSubscription(configuration.Subscription)
-	if err != nil {
-		logging.GlobalLogger.Errorf("Invalid Config: Failed to set subscription: %s", err)
-		return nil, err
-	}
-
 	return &Engine{
 		Configuration: configuration,
 	}, nil

--- a/internal/engine/execution.go
+++ b/internal/engine/execution.go
@@ -56,6 +56,14 @@ func (e *Engine) ExecuteAndRenderSteps(steps []Step, env map[string]string) erro
 	var resourceGroupName string = ""
 	var azureStatus = environments.NewAzureDeploymentStatus()
 
+	err := az.SetSubscription(e.Configuration.Subscription)
+	if err != nil {
+		logging.GlobalLogger.Errorf("Invalid Config: Failed to set subscription: %s", err)
+    azureStatus.SetError(err)
+    environments.ReportAzureStatus(azureStatus, e.Configuration.Environment)
+		return err
+	}
+
 	stepsToExecute := filterDeletionCommands(steps, e.Configuration.DoNotDelete)
 
 	for stepNumber, step := range stepsToExecute {

--- a/internal/engine/testing.go
+++ b/internal/engine/testing.go
@@ -18,6 +18,12 @@ import (
 func (e *Engine) TestSteps(steps []Step, env map[string]string) error {
 	var resourceGroupName string
 	stepsToExecute := filterDeletionCommands(steps, true)
+	err := az.SetSubscription(e.Configuration.Subscription)
+
+	if err != nil {
+		logging.GlobalLogger.Errorf("Invalid Config: Failed to set subscription: %s", err)
+		return err
+	}
 
 	var testRunnerError error = nil
 testRunner:


### PR DESCRIPTION
Setting the subscription currently happens at engine initialization which prevents the failure from being sent to the portal. To temporarily mitigate the issue, this PR sets the subscription within the execution/testing loops to allow the status reports to be sent to the portal