### PR TITLE
[RFC] Add expected_contains tag

### DIFF
--- a/internal/engine/common.go
+++ b/internal/engine/common.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/Azure/InnovationEngine/internal/lib"
@@ -30,8 +31,17 @@ func compareCommandOutputs(
 	actualOutput string,
 	expectedOutput string,
 	expectedSimilarity float64,
+	expectedRegex *regexp.Regexp,
 	expectedOutputLanguage string,
 ) error {
+	if expectedRegex != nil {
+		if !expectedRegex.MatchString(actualOutput) {
+			return fmt.Errorf(ui.ErrorMessageStyle.Render(fmt.Sprintf("Expected output does not match: %q.", expectedRegex)))
+		}
+
+		return nil
+	}
+
 	if strings.ToLower(expectedOutputLanguage) == "json" {
 		logging.GlobalLogger.Debugf(
 			"Comparing JSON strings:\nExpected: %s\nActual%s",
@@ -55,12 +65,15 @@ func compareCommandOutputs(
 			expectedSimilarity,
 			results.Score,
 		)
-	} else {
-		score := smetrics.JaroWinkler(expectedOutput, actualOutput, 0.7, 4)
 
-		if expectedSimilarity > score {
-			return fmt.Errorf(ui.ErrorMessageStyle.Render("Expected output does not match actual output."))
-		}
+		return nil
+	}
+
+	// Default case, using similarity on non JSON block.
+	score := smetrics.JaroWinkler(expectedOutput, actualOutput, 0.7, 4)
+
+	if expectedSimilarity > score {
+		return fmt.Errorf(ui.ErrorMessageStyle.Render("Expected output does not match actual output."))
 	}
 
 	return nil

--- a/internal/engine/execution.go
+++ b/internal/engine/execution.go
@@ -150,9 +150,10 @@ func (e *Engine) ExecuteAndRenderSteps(steps []Step, env map[string]string) erro
 							actualOutput := commandOutput.StdOut
 							expectedOutput := block.ExpectedOutput.Content
 							expectedSimilarity := block.ExpectedOutput.ExpectedSimilarity
+							expectedRegex := block.ExpectedOutput.ExpectedRegex
 							expectedOutputLanguage := block.ExpectedOutput.Language
 
-							outputComparisonError := compareCommandOutputs(actualOutput, expectedOutput, expectedSimilarity, expectedOutputLanguage)
+							outputComparisonError := compareCommandOutputs(actualOutput, expectedOutput, expectedSimilarity, expectedRegex, expectedOutputLanguage)
 
 							if outputComparisonError != nil {
 								logging.GlobalLogger.Errorf("Error comparing command outputs: %s", outputComparisonError.Error())

--- a/internal/engine/testing.go
+++ b/internal/engine/testing.go
@@ -55,9 +55,10 @@ testRunner:
 						actualOutput := commandOutput.StdOut
 						expectedOutput := block.ExpectedOutput.Content
 						expectedSimilarity := block.ExpectedOutput.ExpectedSimilarity
+						expectedRegex := block.ExpectedOutput.ExpectedRegex
 						expectedOutputLanguage := block.ExpectedOutput.Language
 
-						err := compareCommandOutputs(actualOutput, expectedOutput, expectedSimilarity, expectedOutputLanguage)
+						err := compareCommandOutputs(actualOutput, expectedOutput, expectedSimilarity, expectedRegex, expectedOutputLanguage)
 
 						if err != nil {
 							logging.GlobalLogger.Errorf("Error comparing command outputs: %s", err.Error())

--- a/internal/parsers/markdown_test.go
+++ b/internal/parsers/markdown_test.go
@@ -76,3 +76,50 @@ func TestParsingMarkdownCodeBlocks(t *testing.T) {
 	})
 
 }
+
+func TestParsingMarkdownExpectedSimilarty(t *testing.T) {
+
+	t.Run("Markdown with a expected_similarty tag using float", func(t *testing.T) {
+		markdown := []byte(fmt.Sprintf("```bash\n%s\n```\n<!--expected_similarity=0.8-->\n```\nHello\n```\n", "echo Hello"))
+
+		document := ParseMarkdownIntoAst(markdown)
+		codeBlocks := ExtractCodeBlocksFromAst(document, markdown, []string{"bash"})
+
+		if len(codeBlocks) != 1 {
+			t.Errorf("Code block count is wrong: %d", len(codeBlocks))
+		}
+
+		block := codeBlocks[0].ExpectedOutput
+		expectedFloat := .8
+		if block.ExpectedSimilarity != expectedFloat {
+			t.Errorf("ExpectedSimilarity is wrong, got %f, expected %f", block.ExpectedSimilarity, expectedFloat)
+		}
+	})
+
+}
+
+func TestParsingMarkdownExpectedRegex(t *testing.T) {
+
+	t.Run("Markdown with a expected_similarty tag using regex", func(t *testing.T) {
+		markdown := []byte(fmt.Sprintf("```bash\n%s\n```\n<!--expected_similarity=\"Foo \\w+\"-->\n```\nFoo Bar\n```\n", "echo 'Foo Bar'"))
+
+		document := ParseMarkdownIntoAst(markdown)
+		codeBlocks := ExtractCodeBlocksFromAst(document, markdown, []string{"bash"})
+
+		if len(codeBlocks) != 1 {
+			t.Errorf("Code block count is wrong: %d", len(codeBlocks))
+		}
+
+		block := codeBlocks[0].ExpectedOutput
+		if block.ExpectedRegex == nil {
+			t.Errorf("ExpectedRegex is nil")
+		}
+
+		stringRegex := block.ExpectedRegex.String()
+		expectedRegex := `Foo \w+`
+		if stringRegex != expectedRegex {
+			t.Errorf("ExpectedRegex is wrong, got %q, expected %q", stringRegex, expectedRegex)
+		}
+	})
+
+}

--- a/tutorial.md
+++ b/tutorial.md
@@ -22,6 +22,18 @@ It also can test the output to make sure everything ran as planned.
 Hello world
 ```
 
+# Test Code block matches expected regex
+
+```bash
+echo "Foo Bar"
+```
+
+It also can test the output to make sure everything ran as planned.
+<!--expected_similarity="Foo \w+"-->
+```
+Foo Bar
+```
+
 # Executable vs non-executable code blocks
 Innovation engine supports code blocks which are both executable and non-executable. A code block is executable if the label/tag after the bash scripts is one of the supported executable tags. Those tags are: bash, terraform, azurecli-interactive, and azurecli.
 


### PR DESCRIPTION
Hi.


In this PR, I added a new `expected_contains` tag.
This tag basically checks the output contains the given string, `tutorial.md` was updated to reflect this change:

```bash
$ ./bin/ie test tutorial.md
Welcome to the innovation Engine Tutorial
  1. Running simple bash commands
  ✔

  2. Test Code block with expected output
  ✔

  3. Test Code block contains expected output
  ✔
```

As a result, the test fails with the following patch applied:

```patch
diff --git a/tutorial.md b/tutorial.md
index 05751cc..756bcff 100644
--- a/tutorial.md
+++ b/tutorial.md
@@ -29,7 +29,7 @@ echo "Foo Bar"
 \`\`\`

 It also can test the output to make sure everything ran as planned.
-<!--expected_contains="Foo"-->
+<!--expected_contains="Quux"-->
 \`\`\`
 Foo Bar
 \`\`\`
```

```
$ ./bin/ie test tutorial.md
Welcome to the innovation Engine Tutorial
  1. Running simple bash commands
  ✔

  2. Test Code block with expected output
  ✔

  3. Test Code block contains expected output
  \Error when comparing the command outputs: %s
  ✔ ected output does not contain: "Quux".
```

If you see any way to improve this contribution, feel free to share.


Best regards and thank you in advance.