### PR TITLE
[fix] restoration of env vars

### DIFF
--- a/internal/shells/bash.go
+++ b/internal/shells/bash.go
@@ -38,7 +38,12 @@ func loadEnvFile(path string) (map[string]string, error) {
 		line := scanner.Text()
 		if strings.Contains(line, "=") {
 			parts := strings.SplitN(line, "=", 2) // Split at the first "=" only
-			env[parts[0]] = parts[1]
+			v := parts[1]
+			if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+				// Remove leading and trailing quotes
+				v = v[1 : len(v)-1]
+			}
+			env[parts[0]] = v
 		}
 	}
 	return env, nil

--- a/internal/shells/bash.go
+++ b/internal/shells/bash.go
@@ -38,12 +38,12 @@ func loadEnvFile(path string) (map[string]string, error) {
 		line := scanner.Text()
 		if strings.Contains(line, "=") {
 			parts := strings.SplitN(line, "=", 2) // Split at the first "=" only
-			v := parts[1]
-			if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+			value := parts[1]
+			if len(value) >= 2 && value[0] == '"' && value[len(value)-1] == '"' {
 				// Remove leading and trailing quotes
-				v = v[1 : len(v)-1]
+				value = value[1 : len(value)-1]
 			}
-			env[parts[0]] = v
+			env[parts[0]] = value
 		}
 	}
 	return env, nil


### PR DESCRIPTION
At the end of each step, the environment variables are written as-is to a state file. When the execution completes, the final set of environment variables are further processed, with the values being quoted. Subsequent executions fail as `$HOME` has the value `"/home/azureuser"` instead of `/home/azureuser` which breaks the `az` cli. This fix trims the leading and trailing quotes when loading the state file.