### PR TITLE
Add manual scenario testing invocation and drop the requirement for running them on pull requests.

### DIFF
--- a/.github/workflows/scenario-testing.yaml
+++ b/.github/workflows/scenario-testing.yaml
@@ -8,6 +8,8 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
+
 jobs:
   test-ocd-scenarios:
     runs-on: ubuntu-latest

--- a/.github/workflows/scenario-testing.yaml
+++ b/.github/workflows/scenario-testing.yaml
@@ -23,9 +23,11 @@ jobs:
           creds: ${{ secrets.AZURE_CREDENTIALS }}
       - name: Run all one click deployment scenarios.
         uses: azure/CLI@v1
+        if: github.event_name != 'pull_request'
         with:
           inlineScript: |
             make test-scenarios SUBSCRIPTION=${{ secrets.AZURE_SUBSCRIPTION }}
       - name: Display ie.log file
+        if: github.event_name != 'pull_request'
         run: |
           cat ie.log


### PR DESCRIPTION
The scenarios that we test require a secret that is only available to our repository which causes PRs from forks to never pass pipeline checks. This prevents the scenario testing from happening on pull requests and adds a workflow dispatch trigger to manually invoke the pipeline.