### PR TITLE
Update the bash command execution to specify `set -e` when executing.

### DIFF
--- a/internal/shells/bash.go
+++ b/internal/shells/bash.go
@@ -129,7 +129,7 @@ type BashCommandConfiguration struct {
 // Executes a bash command and returns the output or error.
 func ExecuteBashCommand(command string, config BashCommandConfiguration) (CommandOutput, error) {
 	var commandWithStateSaved = []string{
-    "set -e",
+		"set -e",
 		command,
 		"IE_LAST_COMMAND_EXIT_CODE=\"$?\"",
 		"env > " + environmentStateFile,

--- a/internal/shells/bash.go
+++ b/internal/shells/bash.go
@@ -129,6 +129,7 @@ type BashCommandConfiguration struct {
 // Executes a bash command and returns the output or error.
 func ExecuteBashCommand(command string, config BashCommandConfiguration) (CommandOutput, error) {
 	var commandWithStateSaved = []string{
+    "set -e",
 		command,
 		"IE_LAST_COMMAND_EXIT_CODE=\"$?\"",
 		"env > " + environmentStateFile,

--- a/internal/shells/bash_test.go
+++ b/internal/shells/bash_test.go
@@ -89,4 +89,65 @@ func TestBashCommandExecution(t *testing.T) {
 			t.Errorf("Expected result to be non-empty, got '%s'", result.StdOut)
 		}
 	})
+
+	t.Run("Invalid command execution", func(t *testing.T) {
+		cmd := "not_real_command"
+		_, err := ExecuteBashCommand(
+			cmd,
+			BashCommandConfiguration{
+				EnvironmentVariables: nil,
+				InheritEnvironment:   true,
+				InteractiveCommand:   false,
+				WriteToHistory:       false,
+			},
+		)
+
+		if err == nil {
+			t.Errorf("Expected an error to occur, but the command succeeded.")
+		}
+
+	})
+
+	t.Run("Command with multiple commands", func(t *testing.T) {
+		cmd := "printf hello; printf world"
+		result, err := ExecuteBashCommand(
+			cmd,
+			BashCommandConfiguration{
+				EnvironmentVariables: nil,
+				InheritEnvironment:   true,
+				InteractiveCommand:   false,
+				WriteToHistory:       false,
+			},
+		)
+		if err != nil {
+			t.Errorf("Expected err to be nil, got %v", err)
+		}
+		if result.StdOut != "helloworld" {
+			t.Errorf("Expected result to be non-empty, got '%s'", result.StdOut)
+		}
+	})
+
+	t.Run("Command with environment variables", func(t *testing.T) {
+		cmd := "printf $TEST_ENV_VAR"
+		result, err := ExecuteBashCommand(
+			cmd,
+			BashCommandConfiguration{
+				EnvironmentVariables: map[string]string{
+					"TEST_ENV_VAR": "hello",
+				},
+				InheritEnvironment: true,
+				InteractiveCommand: false,
+				WriteToHistory:     false,
+			},
+		)
+
+		if err != nil {
+			t.Errorf("Expected err to be nil, got %v", err)
+		}
+
+		if result.StdOut != "hello" {
+			t.Errorf("Expected result to be non-empty, got '%s'", result.StdOut)
+		}
+	})
+
 }

--- a/internal/shells/bash_test.go
+++ b/internal/shells/bash_test.go
@@ -70,7 +70,7 @@ func TestEnvironmentVariableValidationAndFiltering(t *testing.T) {
 }
 
 func TestBashCommandExecution(t *testing.T) {
-	// Test command execution
+	// Ensures that if a command succeeds, the output is returned.
 	t.Run("Valid command execution", func(t *testing.T) {
 		cmd := "printf hello"
 		result, err := ExecuteBashCommand(
@@ -90,6 +90,7 @@ func TestBashCommandExecution(t *testing.T) {
 		}
 	})
 
+	// Ensures that if a command fails, an error is returned.
 	t.Run("Invalid command execution", func(t *testing.T) {
 		cmd := "not_real_command"
 		_, err := ExecuteBashCommand(
@@ -108,6 +109,7 @@ func TestBashCommandExecution(t *testing.T) {
 
 	})
 
+	// Test the execution of commands with multiple subcommands.
 	t.Run("Command with multiple subcommands", func(t *testing.T) {
 		cmd := "printf hello; printf world"
 		result, err := ExecuteBashCommand(
@@ -127,6 +129,8 @@ func TestBashCommandExecution(t *testing.T) {
 		}
 	})
 
+	// Ensures that if one of the subcommands fail, the other commands do
+	// as well.
 	t.Run("Command with multiple subcommands exits on first error", func(t *testing.T) {
 		cmd := "printf hello; not_real_command; printf world"
 		_, err := ExecuteBashCommand(
@@ -142,8 +146,11 @@ func TestBashCommandExecution(t *testing.T) {
 		if err == nil {
 			t.Errorf("Expected an error to occur, but the command succeeded.")
 		}
+
 	})
 
+	// Ensures that commands can access environment variables passed into
+	// the configuration.
 	t.Run("Command with environment variables", func(t *testing.T) {
 		cmd := "printf $TEST_ENV_VAR"
 		result, err := ExecuteBashCommand(

--- a/internal/shells/bash_test.go
+++ b/internal/shells/bash_test.go
@@ -53,14 +53,40 @@ func TestEnvironmentVariableValidationAndFiltering(t *testing.T) {
 			"_AnotherValidKey": "value2",
 		}
 
-    if len(validEnvMap) != len(expectedValidEnvMap) {
-      t.Errorf("Expected validEnvMap to have %d keys, got %d", len(expectedValidEnvMap), len(validEnvMap))
-    }
+		if len(validEnvMap) != len(expectedValidEnvMap) {
+			t.Errorf(
+				"Expected validEnvMap to have %d keys, got %d",
+				len(expectedValidEnvMap),
+				len(validEnvMap),
+			)
+		}
 
 		for key, value := range validEnvMap {
 			if expectedValue, ok := expectedValidEnvMap[key]; !ok || value != expectedValue {
 				t.Errorf("Expected validEnvMap[%s] to be %s, got %s", key, expectedValue, value)
 			}
+		}
+	})
+}
+
+func TestBashCommandExecution(t *testing.T) {
+	// Test command execution
+	t.Run("Valid command execution", func(t *testing.T) {
+		cmd := "printf hello"
+		result, err := ExecuteBashCommand(
+			cmd,
+			BashCommandConfiguration{
+				EnvironmentVariables: nil,
+				InheritEnvironment:   true,
+				InteractiveCommand:   false,
+				WriteToHistory:       false,
+			},
+		)
+		if err != nil {
+			t.Errorf("Expected err to be nil, got %v", err)
+		}
+		if result.StdOut != "hello" {
+			t.Errorf("Expected result to be non-empty, got '%s'", result.StdOut)
 		}
 	})
 }

--- a/internal/shells/bash_test.go
+++ b/internal/shells/bash_test.go
@@ -108,7 +108,7 @@ func TestBashCommandExecution(t *testing.T) {
 
 	})
 
-	t.Run("Command with multiple commands", func(t *testing.T) {
+	t.Run("Command with multiple subcommands", func(t *testing.T) {
 		cmd := "printf hello; printf world"
 		result, err := ExecuteBashCommand(
 			cmd,
@@ -124,6 +124,23 @@ func TestBashCommandExecution(t *testing.T) {
 		}
 		if result.StdOut != "helloworld" {
 			t.Errorf("Expected result to be non-empty, got '%s'", result.StdOut)
+		}
+	})
+
+	t.Run("Command with multiple subcommands exits on first error", func(t *testing.T) {
+		cmd := "printf hello; not_real_command; printf world"
+		_, err := ExecuteBashCommand(
+			cmd,
+			BashCommandConfiguration{
+				EnvironmentVariables: nil,
+				InheritEnvironment:   true,
+				InteractiveCommand:   false,
+				WriteToHistory:       false,
+			},
+		)
+
+		if err == nil {
+			t.Errorf("Expected an error to occur, but the command succeeded.")
 		}
 	})
 


### PR DESCRIPTION
This PR allows for the innovation engine to correctly terminate a code block after any command inside of it has failed. Previously the innovation engine would rely on the last command in the code block being executed to check for & report failure which meant that code blocks which executed multiple commands would not fail if any command other than the last one had an error.