### PR TITLE
Add installation command for ie.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY_DIR := bin
 IE_BINARY := $(BINARY_DIR)/ie
-AI_BINARY := $(BINARY_DIR)/api
+API_BINARY := $(BINARY_DIR)/api
 
 # -------------------------- Native build targets ------------------------------
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ build-runner: build-ie build-api
 
 build-all: build-ie build-api build-runner
 
-# ------------------------------ Install targets ----------------------------------
+# ------------------------------ Install targets -------------------------------
 
 install-ie:
 	@echo "Installing the Innovation Engine CLI..."

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 BINARY_DIR := bin
 IE_BINARY := $(BINARY_DIR)/ie
-API_BINARY := $(BINARY_DIR)/api
+AI_BINARY := $(BINARY_DIR)/api
 
 # -------------------------- Native build targets ------------------------------
 
@@ -19,6 +19,12 @@ build-runner: build-ie build-api
 	@CGO_ENABLED=0 go build -o "$(BINARY_DIR)/runner" cmd/runner/main.go
 
 build-all: build-ie build-api build-runner
+
+# ------------------------------ Install targets ----------------------------------
+
+install-ie:
+	@echo "Installing the Innovation Engine CLI..."
+	@CGO_ENABLED=0 go install cmd/ie/ie.go
 
 # ------------------------------ Test targets ----------------------------------
 


### PR DESCRIPTION
This adds `make install-ie` so that you can install ie into your GOPATH.