### PR TITLE
Update install_from_release.sh to account for localized files

### DIFF
--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -9,7 +9,7 @@ lang=${1:-''}
 if [ "$lang" = "" ]; then
   scenarios='https://github.com/Azure/InnovationEngine/releases/download/latest/scenarios.zip'
 # Otherwise, download the scenarios from Microsoft Docs in the appropriate langauge
-else if [ "$lang" = "en-us" ]; then
+elif [ "$lang" = "en-us" ]; then
   scenarios='https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/scenarios.zip'
 else
   scenarios="https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/$lang-scenarios.zip"

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -7,13 +7,13 @@ SCENARIOS=""
 
 # Map the language parameter to the corresponding scenarios file
 # If no parameter, download the scenarios from IE
-if [ "$lang" = "" ]; then
+if [ "$LANG" = "" ]; then
   SCENARIOS='https://github.com/Azure/InnovationEngine/releases/download/latest/scenarios.zip'
 # Otherwise, download the scenarios from Microsoft Docs in the appropriate langauge
-elif [ "$lang" = "en-us" ]; then
+elif [ "$LANG" = "en-us" ]; then
   SCENARIOS='https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/scenarios.zip'
 else
-  SCENARIOS="https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/$lang-scenarios.zip"
+  SCENARIOS="https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/$LANG-scenarios.zip"
 fi
 
 # Download the binary from the latest

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -1,3 +1,4 @@
+# Script to install scenarios file.  Pass in language code parameter for a particular language, such as it-it for Italian.
 set -e
 
 # Define the language parameter (default is 'en')

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -1,20 +1,24 @@
 # Script to install scenarios file.  Pass in language code parameter for a particular language, such as it-it for Italian.
 set -e
 
-# Define the language parameter (default is 'en')
-lang=${1:-'en'}
+# Define the language parameter
+lang=${1:-''}
 
 # Map the language parameter to the corresponding scenarios file
-if [ "$lang" = "en" ]; then
-  scenarios='scenarios.zip'
+# If no parameter, download the scenarios from IE
+if [ "$lang" = "" ]; then
+  scenarios='https://github.com/Azure/InnovationEngine/releases/download/latest/scenarios.zip'
+# Otherwise, download the scenarios from Microsoft Docs in the appropriate langauge
+else if [ "$lang" = "en-us" ]; then
+  scenarios='https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/scenarios.zip'
 else
-  scenarios="$lang-scenarios.zip"
+  scenarios="https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/$lang-scenarios.zip"
 fi
 
 # Download the binary from the latest
 echo "Installing IE & scenarios from the latest release..."
 wget -q -O ie https://github.com/Azure/InnovationEngine/releases/download/latest/ie > /dev/null
-wget -q -O scenarios.zip https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/$scenarios > /dev/null
+wget -q -O scenarios.zip "$scenarios" > /dev/null
 
 # Setup permissions & move to the local bin
 chmod +x ie > /dev/null

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -13,7 +13,7 @@ fi
 # Download the binary from the latest
 echo "Installing IE & scenarios from the latest release..."
 wget -q -O ie https://github.com/Azure/InnovationEngine/releases/download/latest/ie > /dev/null
-wget -q -O scenarios.zip "https://github.com/MicrosoftDocs/executable-docs/releases/download/latest/$scenarios?branch=your_branch_name" > /dev/null
+wget -q -O scenarios.zip "https://github.com/MicrosoftDocs/executable-docs/releases/download/latest/$scenarios?branch=live" > /dev/null
 
 # Setup permissions & move to the local bin
 chmod +x ie > /dev/null

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -13,7 +13,7 @@ fi
 # Download the binary from the latest
 echo "Installing IE & scenarios from the latest release..."
 wget -q -O ie https://github.com/Azure/InnovationEngine/releases/download/latest/ie > /dev/null
-wget -q -O scenarios.zip https://github.com/MicrosoftDocs/executable-docs/releases/download/v.1.0.1/$scenarios > /dev/null
+wget -q -O scenarios.zip https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/$scenarios > /dev/null
 
 # Setup permissions & move to the local bin
 chmod +x ie > /dev/null

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -1,9 +1,19 @@
 set -e
 
+# Define the language parameter (default is 'en')
+lang=${1:-'en'}
+
+# Map the language parameter to the corresponding scenarios file
+if [ "$lang" = "en" ]; then
+  scenarios='scenarios.zip'
+else
+  scenarios="$lang-scenarios.zip"
+fi
+
 # Download the binary from the latest
 echo "Installing IE & scenarios from the latest release..."
 wget -q -O ie https://github.com/Azure/InnovationEngine/releases/download/latest/ie > /dev/null
-wget -q -O scenarios.zip https://github.com/Azure/InnovationEngine/releases/download/latest/scenarios.zip > /dev/null
+wget -q -O scenarios.zip https://github.com/Azure/InnovationEngine/releases/download/latest/$scenarios > /dev/null
 
 # Setup permissions & move to the local bin
 chmod +x ie > /dev/null

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -13,7 +13,7 @@ fi
 # Download the binary from the latest
 echo "Installing IE & scenarios from the latest release..."
 wget -q -O ie https://github.com/Azure/InnovationEngine/releases/download/latest/ie > /dev/null
-wget -q -O scenarios.zip https://github.com/MicrosoftDocs/executable-docs/releases/download/latest/$scenarios > /dev/null
+wget -q -O scenarios.zip "https://github.com/MicrosoftDocs/executable-docs/releases/download/latest/$scenarios?branch=your_branch_name" > /dev/null
 
 # Setup permissions & move to the local bin
 chmod +x ie > /dev/null

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -13,7 +13,7 @@ fi
 # Download the binary from the latest
 echo "Installing IE & scenarios from the latest release..."
 wget -q -O ie https://github.com/Azure/InnovationEngine/releases/download/latest/ie > /dev/null
-wget -q -O scenarios.zip https://github.com/MicrosoftDocs/executable-docs/releases/download/latest/$scenarios > /dev/null
+wget -q -O scenarios.zip https://github.com/MicrosoftDocs/executable-docs/releases/download/v.1.0.1/$scenarios > /dev/null
 
 # Setup permissions & move to the local bin
 chmod +x ie > /dev/null

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -13,7 +13,7 @@ fi
 # Download the binary from the latest
 echo "Installing IE & scenarios from the latest release..."
 wget -q -O ie https://github.com/Azure/InnovationEngine/releases/download/latest/ie > /dev/null
-wget -q -O scenarios.zip https://github.com/Azure/InnovationEngine/releases/download/latest/$scenarios > /dev/null
+wget -q -O scenarios.zip https://github.com/MicrosoftDocs/executable-docs/releases/download/latest/$scenarios > /dev/null
 
 # Setup permissions & move to the local bin
 chmod +x ie > /dev/null

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -2,23 +2,24 @@
 set -e
 
 # Define the language parameter
-lang=${1:-''}
+LANG="${1:-''}"
+SCENARIOS=""
 
 # Map the language parameter to the corresponding scenarios file
 # If no parameter, download the scenarios from IE
 if [ "$lang" = "" ]; then
-  scenarios='https://github.com/Azure/InnovationEngine/releases/download/latest/scenarios.zip'
+  SCENARIOS='https://github.com/Azure/InnovationEngine/releases/download/latest/scenarios.zip'
 # Otherwise, download the scenarios from Microsoft Docs in the appropriate langauge
 elif [ "$lang" = "en-us" ]; then
-  scenarios='https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/scenarios.zip'
+  SCENARIOS='https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/scenarios.zip'
 else
-  scenarios="https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/$lang-scenarios.zip"
+  SCENARIOS="https://github.com/MicrosoftDocs/executable-docs/releases/download/v1.0.1/$lang-scenarios.zip"
 fi
 
 # Download the binary from the latest
 echo "Installing IE & scenarios from the latest release..."
 wget -q -O ie https://github.com/Azure/InnovationEngine/releases/download/latest/ie > /dev/null
-wget -q -O scenarios.zip "$scenarios" > /dev/null
+wget -q -O scenarios.zip "$SCENARIOS" > /dev/null
 
 # Setup permissions & move to the local bin
 chmod +x ie > /dev/null

--- a/scripts/install_from_release.sh
+++ b/scripts/install_from_release.sh
@@ -13,7 +13,7 @@ fi
 # Download the binary from the latest
 echo "Installing IE & scenarios from the latest release..."
 wget -q -O ie https://github.com/Azure/InnovationEngine/releases/download/latest/ie > /dev/null
-wget -q -O scenarios.zip "https://github.com/MicrosoftDocs/executable-docs/releases/download/latest/$scenarios?branch=live" > /dev/null
+wget -q -O scenarios.zip https://github.com/MicrosoftDocs/executable-docs/releases/download/latest/$scenarios > /dev/null
 
 # Setup permissions & move to the local bin
 chmod +x ie > /dev/null


### PR DESCRIPTION
install_from_release.sh now downloads from https://github.com/MicrosoftDocs/executable-docs/releases/tag/v1.0.1.  When ran with a language code parameter, such as it-it for Italian, it will grab the zip file for that particular language.