### PR TITLE
fix(scenarios): Fix the regex that locates variables to override

### DIFF
--- a/internal/engine/scenario.go
+++ b/internal/engine/scenario.go
@@ -68,7 +68,7 @@ func downloadScenarioMarkdown(url string) ([]byte, error) {
 	return body, nil
 }
 
-// Given either a local or remote path to a markdown file, resolve the path to 
+// Given either a local or remote path to a markdown file, resolve the path to
 // the markdown file and return the contents of the file.
 func resolveMarkdownSource(path string) ([]byte, error) {
 	if strings.HasPrefix(path, "https://") || strings.HasPrefix(path, "http://") {
@@ -128,8 +128,9 @@ func CreateScenarioFromMarkdown(
 
 	varsToExport := lib.CopyMap(environmentVariableOverrides)
 	for key, value := range environmentVariableOverrides {
+		environmentVariables[key] = value
 		logging.GlobalLogger.Debugf("Attempting to override %s with %s", key, value)
-		exportRegex := regexp.MustCompile(fmt.Sprintf(`export %s=["']?([a-z-A-Z0-9_]+)["']?`, key))
+		exportRegex := regexp.MustCompile(fmt.Sprintf(`(?m)export %s\s*=\s*(.*?)(;|&&|$)`, key))
 
 		for index, codeBlock := range codeBlocks {
 			matches := exportRegex.FindAllStringSubmatch(codeBlock.Content, -1)
@@ -150,7 +151,7 @@ func CreateScenarioFromMarkdown(
 				oldValue := match[1]
 
 				// Replace the old export with the new export statement
-				newLine := strings.Replace(oldLine, oldValue, value, 1)
+				newLine := strings.Replace(oldLine, oldValue, value+" ", 1)
 				logging.GlobalLogger.Debugf("Replacing '%s' with '%s'", oldLine, newLine)
 
 				// Update the code block with the new export statement

--- a/scenarios/testing/variables.md
+++ b/scenarios/testing/variables.md
@@ -1,0 +1,37 @@
+# Variable declaration and usage
+
+## Simple declaration
+
+```bash
+export MY_VAR="Hello, World!"
+echo $MY_VAR
+```
+
+## Double variable declaration
+
+```bash
+export NEXT_VAR="Hello" && export OTHER_VAR="Hello, World!"
+echo $NEXT_VAR
+```
+
+## Double declaration with semicolon
+
+```bash
+export THIS_VAR="Hello"; export THAT_VAR="Hello, World!"
+echo $OTHER_VAR
+```
+
+## Declaration with subshell value
+
+```bash
+export SUBSHELL_VARIABLE=$(echo "Hello, World!")
+echo $SUBSHELL_VARIABLE
+```
+
+## Declaration with other variable in value
+
+```bash
+export VAR1="Hello"
+export VAR2="$VAR1, World!"
+echo $VAR2
+```


### PR DESCRIPTION
This PR updates the regex used to find exported variables in a scenario that have more complex declarations (I.E. variables that get values from sub-shells, variables that are defined on the same line as another, etc). This PR fixes #199 and tests have been added to ensure that this issue doesn't arise again.