### PR TITLE
fix(scenario): Allow for markdown files to not specify h1 headers

### DIFF
--- a/internal/engine/common/scenario.go
+++ b/internal/engine/common/scenario.go
@@ -184,9 +184,16 @@ func CreateScenarioFromMarkdown(
 
 	// Group the code blocks into steps.
 	steps := groupCodeBlocksIntoSteps(codeBlocks)
+
+	// If no title is found, we simply use the name of the markdown file as
+	// the title of the scenario.
 	title, err := parsers.ExtractScenarioTitleFromAst(markdown, source)
 	if err != nil {
-		return nil, err
+		logging.GlobalLogger.Warnf(
+			"Failed to extract scenario title: '%s'. Using the name of the markdown as the scenario title",
+			err,
+		)
+		title = filepath.Base(path)
 	}
 
 	logging.GlobalLogger.Infof("Successfully built out the scenario: %s", title)

--- a/internal/engine/common/scenario_test.go
+++ b/internal/engine/common/scenario_test.go
@@ -105,6 +105,31 @@ func TestScenarioParsing(t *testing.T) {
 		fmt.Println(scenario)
 		assert.Equal(t, filepath.Base(path), scenario.Name)
 	})
+
+	// Test parsing a scenario from markdown
+	t.Run("Parse scenario that does have an h1 tag to use for it's title", func(t *testing.T) {
+		content := "# Scenario-title\nTest content from local file"
+		temporaryFile, err := os.CreateTemp("", "example")
+		if err != nil {
+			t.Fatalf("Error creating temporary file: %v", err)
+		}
+		defer os.Remove(temporaryFile.Name())
+
+		if _, err := temporaryFile.Write([]byte(content)); err != nil {
+			t.Fatalf("Error writing to temporary file: %v", err)
+		}
+		if err := temporaryFile.Close(); err != nil {
+			t.Fatalf("Error closing temporary file: %v", err)
+		}
+
+		path := temporaryFile.Name()
+
+		scenario, err := CreateScenarioFromMarkdown(path, []string{"bash"}, nil)
+
+		assert.NoError(t, err)
+		fmt.Println(scenario)
+		assert.Equal(t, "Scenario-title", scenario.Name)
+	})
 }
 
 func TestVariableOverrides(t *testing.T) {

--- a/internal/engine/common/scenario_test.go
+++ b/internal/engine/common/scenario_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -76,6 +77,33 @@ func TestResolveMarkdownSource(t *testing.T) {
 		if !strings.Contains(err.Error(), expectedErrorMsg) {
 			t.Errorf("Expected error message to contain %q, got %q", expectedErrorMsg, err.Error())
 		}
+	})
+}
+
+func TestScenarioParsing(t *testing.T) {
+	// Test parsing a scenario from markdown
+	t.Run("Parse scenario that doesn't have an h1 tag to use for it's title", func(t *testing.T) {
+		content := "Test content from local file"
+		temporaryFile, err := os.CreateTemp("", "example")
+		if err != nil {
+			t.Fatalf("Error creating temporary file: %v", err)
+		}
+		defer os.Remove(temporaryFile.Name())
+
+		if _, err := temporaryFile.Write([]byte(content)); err != nil {
+			t.Fatalf("Error writing to temporary file: %v", err)
+		}
+		if err := temporaryFile.Close(); err != nil {
+			t.Fatalf("Error closing temporary file: %v", err)
+		}
+
+		path := temporaryFile.Name()
+
+		scenario, err := CreateScenarioFromMarkdown(path, []string{"bash"}, nil)
+
+		assert.NoError(t, err)
+		fmt.Println(scenario)
+		assert.Equal(t, filepath.Base(path), scenario.Name)
 	})
 }
 

--- a/internal/parsers/markdown.go
+++ b/internal/parsers/markdown.go
@@ -75,7 +75,7 @@ func ExtractScenarioTitleFromAst(node ast.Node, source []byte) (string, error) {
 	})
 
 	if header == "" {
-		return "", fmt.Errorf("no header found")
+		return "", fmt.Errorf("no h1 header found to use as the scenario title")
 	}
 
 	return header, nil


### PR DESCRIPTION
h1 headers are currently used to denote the title of the scenario being executed by IE and is currently made a requirement for the scenario to be executed. This PR allows for markdown documents to not specify h1 tags by falling back to using the markdown file name as the title of the scenario if no h1 tags are found within the document.