### PR TITLE
fix(test): Add messaging for communicating the resource group being deleted

### DIFF
--- a/internal/engine/test/model.go
+++ b/internal/engine/test/model.go
@@ -160,6 +160,7 @@ func (model TestModeModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Delete any found resource groups.
 		if model.resourceGroupName != "" {
+			model.CommandLines = append(model.CommandLines, "Attempting to delete the deployed resource group with the name: %s", model.resourceGroupName)
 			logging.GlobalLogger.Infof("Attempting to delete the deployed resource group with the name: %s", model.resourceGroupName)
 			command := fmt.Sprintf("az group delete --name %s --yes --no-wait", model.resourceGroupName)
 			_, err := shells.ExecuteBashCommand(

--- a/internal/engine/test/model.go
+++ b/internal/engine/test/model.go
@@ -160,7 +160,13 @@ func (model TestModeModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 
 		// Delete any found resource groups.
 		if model.resourceGroupName != "" {
-			model.CommandLines = append(model.CommandLines, "Attempting to delete the deployed resource group with the name: %s", model.resourceGroupName)
+			model.CommandLines = append(
+				model.CommandLines,
+				fmt.Sprintf(
+					"Attempting to delete the deployed resource group with the name: %s",
+					model.resourceGroupName,
+				),
+			)
 			logging.GlobalLogger.Infof("Attempting to delete the deployed resource group with the name: %s", model.resourceGroupName)
 			command := fmt.Sprintf("az group delete --name %s --yes --no-wait", model.resourceGroupName)
 			_, err := shells.ExecuteBashCommand(


### PR DESCRIPTION
This communicates the resource group that's being deleted if there is a resource group found at the end of `ie test`.