### PR TITLE
fix(test): Fix test mode to correctly exit when it encounters an error

### DIFF
--- a/cmd/ie/commands/test.go
+++ b/cmd/ie/commands/test.go
@@ -92,7 +92,7 @@ var testCommand = &cobra.Command{
 		err = innovationEngine.TestScenario(scenario)
 		if err != nil {
 			logging.GlobalLogger.Errorf("Error testing scenario: %s", err)
-			fmt.Printf("Error testing scenario: %s\n", err)
+			fmt.Printf("Scenario did not finish successfully.")
 			os.Exit(1)
 		}
 	},

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -131,12 +131,13 @@ func (e *Engine) TestScenario(scenario *common.Scenario) error {
 			)
 		}
 
+		fmt.Println(strings.Join(model.CommandLines, "\n"))
+
 		err = errors.Join(err, model.GetFailure())
 		if err != nil {
 			logging.GlobalLogger.Errorf("Failed to run ie test %s", err)
+			return err
 		}
-
-		fmt.Println(strings.Join(model.CommandLines, "\n"))
 
 		return nil
 	})


### PR DESCRIPTION
This PR fixes `ie test` so that it exits with a failed status code when an error is encountered. This behavior was accidentally changed in `v0.2.0`, but was the default behavior prior to that.