### PR TITLE
Update `ie interactive` to overwrite an executed document with the environment variables that were used.

### DIFF
--- a/.github/workflows/build-test-release-tagged.yaml
+++ b/.github/workflows/build-test-release-tagged.yaml
@@ -1,32 +1,30 @@
 name: build-test-release-tagged
-
 on:
   push:
     tags:
       - v*
-
 jobs:
   build-test-release:
     permissions:
       contents: write
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Build all targets.
-      run: |
-        make build-all
-    - name: Run unit tests across all targets.
-      run: |
-        make test-all
-    - name: Prepare scenarios to be released.
-      run: |
-        sudo apt install zip
-        zip -r scenarios.zip scenarios
-    - name: Release Innovation Engine
-      uses: softprops/action-gh-release@v1
-      with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-        generate_release_notes: true
-        files: |
-          ./bin/ie
-          ./scenarios.zip
+      - uses: actions/checkout@v4
+      - name: Build all targets.
+        run: |
+          make build-all
+      - name: Run unit tests across all targets.
+        run: |
+          make test-all
+      - name: Prepare scenarios to be released.
+        run: |
+          sudo apt install zip
+          zip -r scenarios.zip scenarios
+      - name: Release Innovation Engine
+        uses: softprops/action-gh-release@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          generate_release_notes: true
+          files: |
+            ./bin/ie
+            ./scenarios.zip

--- a/.github/workflows/build-test-release.yaml
+++ b/.github/workflows/build-test-release.yaml
@@ -9,7 +9,7 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build all targets.
         run: |
           make build-all

--- a/.github/workflows/scenario-testing.yaml
+++ b/.github/workflows/scenario-testing.yaml
@@ -16,7 +16,7 @@ jobs:
   test-ie-installation:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Check ie installation
         run: |
           set -e
@@ -38,14 +38,14 @@ jobs:
     # the testing subscription for any branch in this repository.
     environment: ScenarioTesting
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Build & test all targets.
         run: |
           make build-all
           make test-all WITH_COVERAGE=true
           make test-local-scenarios ENVIRONMENT=github-action
       - name: Upload test coverage
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: github.event_name == 'pull_request'
         with:
           name: coverage

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -157,6 +157,7 @@ func (e *Engine) InteractWithScenario(scenario *common.Scenario) error {
 			e.Configuration.Environment,
 			stepsToExecute,
 			lib.CopyMap(scenario.Environment),
+			scenario.GetSourceAsString(),
 		)
 		if err != nil {
 			return err
@@ -181,9 +182,11 @@ func (e *Engine) InteractWithScenario(scenario *common.Scenario) error {
 
 		switch e.Configuration.Environment {
 		case environments.EnvironmentsAzure, environments.EnvironmentsOCD:
+
 			logging.GlobalLogger.Info(
 				"Cleaning environment variable file located at /tmp/env-vars",
 			)
+
 			err := lib.CleanEnvironmentStateFile(lib.DefaultEnvironmentStateFile)
 			if err != nil {
 				logging.GlobalLogger.Errorf("Error cleaning environment variables: %s", err.Error())

--- a/internal/engine/environments/azure.go
+++ b/internal/engine/environments/azure.go
@@ -73,7 +73,7 @@ func (status *AzureDeploymentStatus) SetOutput(output string) {
 	status.Output = output
 }
 
-func (status *AzureDeploymentStatus) SetConfiguredScript(script string) {
+func (status *AzureDeploymentStatus) SetConfiguredMarkdown(script string) {
 	status.ConfiguredMarkdown = script
 }
 

--- a/internal/engine/environments/azure.go
+++ b/internal/engine/environments/azure.go
@@ -81,7 +81,12 @@ func (status *AzureDeploymentStatus) SetOutput(output string) {
 func (status *AzureDeploymentStatus) ConfigureMarkdownForDownload(
 	markdown string,
 	environmentVariables map[string]string,
+	environment string,
 ) {
+	if !IsAzureEnvironment(environment) {
+		return
+	}
+
 	for key, value := range environmentVariables {
 		exportRegex := patterns.ExportVariableRegex(key)
 

--- a/internal/engine/environments/azure.go
+++ b/internal/engine/environments/azure.go
@@ -23,13 +23,13 @@ type AzureStep struct {
 
 // The status of a one-click deployment or learn mode deployment.
 type AzureDeploymentStatus struct {
-	Steps            []AzureStep `json:"steps"`
-	CurrentStep      int         `json:"currentStep"`
-	Status           string      `json:"status"`
-	ResourceURIs     []string    `json:"resourceURIs"`
-	Error            string      `json:"error"`
-	Output           string      `json:"output"`
-	ConfiguredScript string      `json:"configuredScript"`
+	Steps              []AzureStep `json:"steps"`
+	CurrentStep        int         `json:"currentStep"`
+	Status             string      `json:"status"`
+	ResourceURIs       []string    `json:"resourceURIs"`
+	Error              string      `json:"error"`
+	Output             string      `json:"output"`
+	ConfiguredMarkdown string      `json:"configuredMarkdown"`
 }
 
 func NewAzureDeploymentStatus() AzureDeploymentStatus {
@@ -74,7 +74,7 @@ func (status *AzureDeploymentStatus) SetOutput(output string) {
 }
 
 func (status *AzureDeploymentStatus) SetConfiguredScript(script string) {
-	status.ConfiguredScript = script
+	status.ConfiguredMarkdown = script
 }
 
 // Print out the status JSON for azure/cloudshell if in the correct environment.

--- a/internal/engine/environments/azure.go
+++ b/internal/engine/environments/azure.go
@@ -23,12 +23,13 @@ type AzureStep struct {
 
 // The status of a one-click deployment or learn mode deployment.
 type AzureDeploymentStatus struct {
-	Steps        []AzureStep `json:"steps"`
-	CurrentStep  int         `json:"currentStep"`
-	Status       string      `json:"status"`
-	ResourceURIs []string    `json:"resourceURIs"`
-	Error        string      `json:"error"`
-	Output       string      `json:"output"`
+	Steps            []AzureStep `json:"steps"`
+	CurrentStep      int         `json:"currentStep"`
+	Status           string      `json:"status"`
+	ResourceURIs     []string    `json:"resourceURIs"`
+	Error            string      `json:"error"`
+	Output           string      `json:"output"`
+	ConfiguredScript string      `json:"configuredScript"`
 }
 
 func NewAzureDeploymentStatus() AzureDeploymentStatus {
@@ -70,6 +71,10 @@ func (status *AzureDeploymentStatus) SetError(err error) {
 
 func (status *AzureDeploymentStatus) SetOutput(output string) {
 	status.Output = output
+}
+
+func (status *AzureDeploymentStatus) SetConfiguredScript(script string) {
+	status.ConfiguredScript = script
 }
 
 // Print out the status JSON for azure/cloudshell if in the correct environment.

--- a/internal/engine/interactive/interactive.go
+++ b/internal/engine/interactive/interactive.go
@@ -381,7 +381,7 @@ func (model InteractiveModeModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			}
 
 			logging.GlobalLogger.Tracef("Configured markdown source: %s", configuredMarkdownSource)
-			model.azureStatus.SetConfiguredScript(configuredMarkdownSource)
+			model.azureStatus.SetConfiguredMarkdown(configuredMarkdownSource)
 			model.azureStatus.SetOutput(strings.Join(model.CommandLines, "\n"))
 			commands = append(
 				commands,

--- a/internal/engine/interactive/interactive.go
+++ b/internal/engine/interactive/interactive.go
@@ -352,36 +352,7 @@ func (model InteractiveModeModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				model.azureStatus.SetError(err)
 			}
 
-			configuredMarkdownSource := model.markdownSource
-
-			for key, value := range environmentVariables {
-				exportRegex := patterns.ExportVariableRegex(key)
-
-				matches := exportRegex.FindAllStringSubmatch(model.markdownSource, -1)
-
-				if len(matches) != 0 {
-					logging.GlobalLogger.Debugf(
-						"Found %d matches for the environment variable %s, Replacing them in markdown source.",
-						len(matches),
-						key,
-					)
-				}
-
-				for _, match := range matches {
-					oldLine := match[0]
-					oldValue := match[1]
-
-					// Replace the old export with the new export statement
-					newLine := strings.Replace(oldLine, oldValue, value+" ", 1)
-					logging.GlobalLogger.Debugf("Replacing '%s' with '%s'", oldLine, newLine)
-
-					// Update the code block with the new export statement
-					configuredMarkdownSource = strings.Replace(configuredMarkdownSource, oldLine, newLine, 1)
-				}
-			}
-
-			logging.GlobalLogger.Tracef("Configured markdown source: %s", configuredMarkdownSource)
-			model.azureStatus.SetConfiguredMarkdown(configuredMarkdownSource)
+			model.azureStatus.ConfigureMarkdownForDownload(model.markdownSource, environmentVariables)
 			model.azureStatus.SetOutput(strings.Join(model.CommandLines, "\n"))
 			commands = append(
 				commands,

--- a/internal/engine/interactive/interactive.go
+++ b/internal/engine/interactive/interactive.go
@@ -352,7 +352,11 @@ func (model InteractiveModeModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				model.azureStatus.SetError(err)
 			}
 
-			model.azureStatus.ConfigureMarkdownForDownload(model.markdownSource, environmentVariables)
+			model.azureStatus.ConfigureMarkdownForDownload(
+				model.markdownSource,
+				environmentVariables,
+				model.environment,
+			)
 			model.azureStatus.SetOutput(strings.Join(model.CommandLines, "\n"))
 			commands = append(
 				commands,

--- a/internal/patterns/regex.go
+++ b/internal/patterns/regex.go
@@ -1,6 +1,9 @@
 package patterns
 
-import "regexp"
+import (
+	"fmt"
+	"regexp"
+)
 
 var (
 	// An SSH command regex where there must be a username@host somewhere present in the command.
@@ -18,4 +21,8 @@ var (
 	// ARM regex
 	AzResourceURI       = regexp.MustCompile(`\"id\": \"(/subscriptions/[^\"]+)\"`)
 	AzResourceGroupName = regexp.MustCompile(`resourceGroups/([^\"\\/\ ]+)`)
+
+	ExportVariableRegex = func(key string) *regexp.Regexp {
+		return regexp.MustCompile(fmt.Sprintf(`(?m)export %s\s*=\s*(.*?)(;|&&|$)`, key))
+	}
 )


### PR DESCRIPTION
This PR updates `ie interactive` to overwrite the source of an executed document with the environment variables that were used and provide it to the portal before executing. These changes do not affect the standard execution and will not overwrite the actual document.