### PR TITLE
Fix configured markdown to be set before interactive commands are executed

### DIFF
--- a/internal/engine/environments/azure.go
+++ b/internal/engine/environments/azure.go
@@ -36,11 +36,13 @@ type AzureDeploymentStatus struct {
 
 func NewAzureDeploymentStatus() AzureDeploymentStatus {
 	return AzureDeploymentStatus{
-		Steps:        []AzureStep{},
-		CurrentStep:  0,
-		Status:       "Executing",
-		ResourceURIs: []string{},
-		Error:        "",
+		Steps:              []AzureStep{},
+		CurrentStep:        0,
+		Status:             "Executing",
+		ResourceURIs:       []string{},
+		Error:              "",
+		ConfiguredMarkdown: "",
+		Output:             "",
 	}
 }
 
@@ -134,6 +136,7 @@ func ReportAzureStatus(status AzureDeploymentStatus, environment string) {
 		// We add these strings to the output so that the portal can find and parse
 		// the JSON status.
 		ocdStatus := fmt.Sprintf("ie_us%sie_ue", statusJson)
+		logging.GlobalLogger.Tracef("Generated status: %s", ocdStatus)
 		fmt.Println(ui.OcdStatusUpdateStyle.Render(ocdStatus))
 	}
 }

--- a/internal/engine/interactive/interactive.go
+++ b/internal/engine/interactive/interactive.go
@@ -191,6 +191,20 @@ func handleUserInput(
 				model.environment,
 			)
 
+			environmentVariables, err := lib.LoadEnvironmentStateFile(
+				lib.DefaultEnvironmentStateFile,
+			)
+			if err != nil {
+				logging.GlobalLogger.Errorf("Failed to load environment state file: %s", err)
+				model.azureStatus.SetError(err)
+			}
+
+			model.azureStatus.ConfigureMarkdownForDownload(
+				model.markdownSource,
+				environmentVariables,
+				model.environment,
+			)
+
 			commands = append(commands, tea.Sequence(
 				common.UpdateAzureStatus(model.azureStatus, model.environment),
 				func() tea.Msg {


### PR DESCRIPTION
This PR configures the markdown before executing interactive commands, as the final status updates happen before the interactive commands finish executing.